### PR TITLE
fix/ 잘못된 인증 식별자 수정

### DIFF
--- a/src/main/java/com/example/liskovbackend/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/liskovbackend/common/security/JwtAuthenticationFilter.java
@@ -48,19 +48,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         var token = authHeader.substring(7);
-        var email = jwtUtils.extractUsername(token);
+        var userId = jwtUtils.extractUserId(token);
 
-        if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+        if (userId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             if (jwtUtils.validateToken(token)) {
-                var user = userRepository.findByEmail(email).orElse(null);
-
-                if (user != null) {
-                    var authentication = new UsernamePasswordAuthenticationToken(
-                        email, null, new ArrayList<>());
-
-                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                }
+                var authentication = new UsernamePasswordAuthenticationToken(userId, null, new ArrayList<>());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         }
 


### PR DESCRIPTION
사용자 ID가 아닌, 사용자 이메일을 식별자로 사용하고 있었음. 때문에 정상적인 authentication 처리가 안 되던 문제 해결.